### PR TITLE
Fix duplication by setting state of new task to nothing.

### DIFF
--- a/tasklite-core/source/Lib.hs
+++ b/tasklite-core/source/Lib.hs
@@ -1352,6 +1352,7 @@ duplicateTasks conf connection ids = do
             , Task.awake_utc = val_ Nothing
             , Task.closed_utc = val_ Nothing
             , Task.modified_utc = val_ modified_utc
+            , Task.state = val_ Nothing
             }
 
         -- Duplicate tags


### PR DESCRIPTION
This creates the duplicate as open and prevents the previous issue
where the state was set to done but the close trigger would not react
and set a closed date.