### PR TITLE
Add modified command

### DIFF
--- a/tasklite-core/app/Main.hs
+++ b/tasklite-core/app/Main.hs
@@ -861,8 +861,8 @@ executeCLiCommand conf now connection cmd =
     ListNew -> newTasks conf now connection
     ListOld -> listOldTasks conf now connection
     ListOpen -> openTasks conf now connection
-    ListModified -> modifiedTasks conf now connection
-    ListModifiedOnly -> modifiedOnlyTasks conf now connection
+    ListModified -> modifiedTasks conf now connection AllItems 
+    ListModifiedOnly -> modifiedTasks conf now connection ModifiedItemsOnly
     ListOverdue -> overdueTasks conf now connection
     ListRepeating -> listRepeating conf now connection
     ListRecurring -> listRecurring conf now connection

--- a/tasklite-core/app/Main.hs
+++ b/tasklite-core/app/Main.hs
@@ -115,6 +115,7 @@ data Command
   | ListNew
   | ListOld
   | ListOpen
+  | ListModified
   | ListDone
   | ListObsolete
   | ListDeletable
@@ -462,6 +463,9 @@ commandParser conf =
 
     <> command "open" (toParserInfo (pure ListOpen)
         "List all open tasks by priority desc")
+      
+    <> command "modified" (toParserInfo (pure ListModified)
+        "List all modified tasks by modified_utc desc")
 
     -- All tasks due to no later than
     -- <> command "yesterday"
@@ -853,6 +857,7 @@ executeCLiCommand conf now connection cmd =
     ListNew -> newTasks conf now connection
     ListOld -> listOldTasks conf now connection
     ListOpen -> openTasks conf now connection
+    ListModified -> modifiedTasks conf now connection
     ListOverdue -> overdueTasks conf now connection
     ListRepeating -> listRepeating conf now connection
     ListRecurring -> listRecurring conf now connection

--- a/tasklite-core/app/Main.hs
+++ b/tasklite-core/app/Main.hs
@@ -116,6 +116,7 @@ data Command
   | ListOld
   | ListOpen
   | ListModified
+  | ListModifiedOnly
   | ListDone
   | ListObsolete
   | ListDeletable
@@ -465,7 +466,10 @@ commandParser conf =
         "List all open tasks by priority desc")
       
     <> command "modified" (toParserInfo (pure ListModified)
-        "List all modified tasks by modified_utc desc")
+        "List all tasks by modified_utc desc")
+
+    <> command "modified-only" (toParserInfo (pure ListModifiedOnly)
+      "List all modified tasks by modified_utc desc")
 
     -- All tasks due to no later than
     -- <> command "yesterday"
@@ -858,6 +862,7 @@ executeCLiCommand conf now connection cmd =
     ListOld -> listOldTasks conf now connection
     ListOpen -> openTasks conf now connection
     ListModified -> modifiedTasks conf now connection
+    ListModifiedOnly -> modifiedOnlyTasks conf now connection
     ListOverdue -> overdueTasks conf now connection
     ListRepeating -> listRepeating conf now connection
     ListRecurring -> listRecurring conf now connection

--- a/tasklite-core/source/Lib.hs
+++ b/tasklite-core/source/Lib.hs
@@ -1572,31 +1572,34 @@ openTasks conf now connection = do
   pure $ formatTasks conf now tasks
 
 
-modifiedTasks :: Config -> DateTime -> Connection -> IO (Doc AnsiStyle)
-modifiedTasks conf now connection = do
+modifiedTasks 
+  :: Config 
+  -> DateTime 
+  -> Connection 
+  -> ListModifiedFlag 
+  -> IO (Doc AnsiStyle)
+modifiedTasks conf now connection listModifiedFlag = do
   tasks <- query_ connection $ Query
     "select * from `tasks_view` \
     \order by `modified_utc` desc"
-  pure $ formatTasks conf now tasks
-
-
-modifiedOnlyTasks :: Config -> DateTime -> Connection -> IO (Doc AnsiStyle)
-modifiedOnlyTasks conf now connection = 
   let
     filterModified =
       P.filter (\task ->
         (removeNSec $ ulidTextToDateTime $ FullTask.ulid  task)
         /= (parseUtc $ FullTask.modified_utc task))
+
     removeNSec :: Maybe DateTime -> Maybe DateTime
     removeNSec mDateTime =
       case mDateTime of
         Just dateTime -> Just $ dateTime { dtTime = (dtTime dateTime) { todNSec = 0 } }
         Nothing -> Nothing
-  in do
-  tasks <- query_ connection $ Query
-    "select * from `tasks_view` \
-    \order by `modified_utc` desc"
-  pure $ formatTasks conf now $ filterModified tasks
+
+    filteredTasks =
+      case listModifiedFlag of
+        AllItems -> tasks
+        ModifiedItemsOnly -> filterModified tasks
+
+  pure $ formatTasks conf now filteredTasks
 
 
 overdueTasks :: Config -> DateTime -> Connection -> IO (Doc AnsiStyle)

--- a/tasklite-core/source/Lib.hs
+++ b/tasklite-core/source/Lib.hs
@@ -1572,12 +1572,8 @@ openTasks conf now connection = do
   pure $ formatTasks conf now tasks
 
 modifiedTasks :: Config -> DateTime -> Connection -> IO (Doc AnsiStyle)
-modifiedTasks conf now connection = do
-  tasks <- query_ connection $ Query
-    "select * from `tasks_view` \
-    \order by `modified_utc` desc"
-  pure $ formatTasks conf now $ filterModified tasks
-  where
+modifiedTasks conf now connection = 
+  let
     filterModified =
       P.filter (\task ->
         (removeNSec $ ulidTextToDateTime $ FullTask.ulid  task)
@@ -1587,6 +1583,11 @@ modifiedTasks conf now connection = do
       case mDateTime of
         Just dateTime -> Just $ dateTime { dtTime = (dtTime dateTime) { todNSec = 0 } }
         Nothing -> Nothing
+  in do
+  tasks <- query_ connection $ Query
+    "select * from `tasks_view` \
+    \order by `modified_utc` desc"
+  pure $ formatTasks conf now $ filterModified tasks
       
 
 

--- a/tasklite-core/source/Lib.hs
+++ b/tasklite-core/source/Lib.hs
@@ -1571,8 +1571,17 @@ openTasks conf now connection = do
     \order by `priority` desc"
   pure $ formatTasks conf now tasks
 
+
 modifiedTasks :: Config -> DateTime -> Connection -> IO (Doc AnsiStyle)
-modifiedTasks conf now connection = 
+modifiedTasks conf now connection = do
+  tasks <- query_ connection $ Query
+    "select * from `tasks_view` \
+    \order by `modified_utc` desc"
+  pure $ formatTasks conf now tasks
+
+
+modifiedOnlyTasks :: Config -> DateTime -> Connection -> IO (Doc AnsiStyle)
+modifiedOnlyTasks conf now connection = 
   let
     filterModified =
       P.filter (\task ->
@@ -1588,7 +1597,6 @@ modifiedTasks conf now connection =
     "select * from `tasks_view` \
     \order by `modified_utc` desc"
   pure $ formatTasks conf now $ filterModified tasks
-      
 
 
 overdueTasks :: Config -> DateTime -> Connection -> IO (Doc AnsiStyle)

--- a/tasklite-core/source/Utils.hs
+++ b/tasklite-core/source/Utils.hs
@@ -27,6 +27,9 @@ type TagText = Text
 data Filter a = NoFilter | Only a
   deriving (Eq, Ord, Show)
 
+data ListModifiedFlag = AllItems | ModifiedItemsOnly
+  deriving (Eq, Show)
+
 
 (<++>) :: Doc ann -> Doc ann -> Doc ann
 x <++> y =

--- a/tasklite-core/tasklite-core.cabal
+++ b/tasklite-core/tasklite-core.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.34.2.
 --
 -- see: https://github.com/sol/hpack
 --


### PR DESCRIPTION
This adds the modified command as suggested in #18.

Currently it shows all tasks that were modified sorted by the modified_utc. I'm not sure if only showing open tasks would be better. Also when showing these tasks I think we should add a column showing the modified_utc.

What do you think? I will mark this PR as draft until these points are discussed.