### PR TITLE
Fix availab(l)e typos in docs

### DIFF
--- a/docs-source/concepts.md
+++ b/docs-source/concepts.md
@@ -88,7 +88,7 @@ and several other values.
 The idea is that you never have to manually set a priority,
 because it can be derived accurately from other values.
 This of course requires you
-to use the other availabe meta information adequately!
+to use the other available meta information adequately!
 
 The exact calculation algorithm can be found
 in the `taskViewQuery` function in [DbSetup.hs].

--- a/docs-source/installation/desktop_app.md
+++ b/docs-source/installation/desktop_app.md
@@ -4,7 +4,7 @@
 
 **Attention: This is still early alpha**
 
-A few dependencies must be availabe to build the app.
+A few dependencies must be available to build the app.
 To install them on macOS run:
 
 ```shell


### PR DESCRIPTION
Thanks for this software! Love the smooth migration from Taskwarrior.

Spotted a couple of small typos whilst reading the docs. :slightly_smiling_face: 