### PR TITLE
Update document link in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,35 +11,4 @@ CLI task manager built with [Haskell] and [SQLite].
 />
 
 
-## Documentation
-
-- [Introduction](https://tasklite.org/introduction)
-
-- [Installation](https://tasklite.org/installation)
-    - [CLI](https://tasklite.org/installation/cli)
-    - [Desktop App](https://tasklite.org/installation/desktop_app)
-    - [Web App](https://tasklite.org/installation/web_app)
-
-- [Concepts](https://tasklite.org/concepts)
-
-- [Usage](https://tasklite.org/usage)
-    - [CLI](https://tasklite.org/usage/cli)
-    - [Desktop App](https://tasklite.org/usage/desktop_app)
-    - [Web App](https://tasklite.org/usage/web_app)
-    - [REST API](https://tasklite.org/usage/rest_api)
-    - [Haskell API](https://tasklite.org/usage/haskell_api)
-
-- [Differences to Taskwarrior](https://tasklite.org/differences_taskwarrior)
-
-- [Performance](https://tasklite.org/performance)
-
-- [Development](https://tasklite.org/development)
-
-- [Changelog](https://tasklite.org/changelog)
-
-- [Related](https://tasklite.org/related)
-
-
-[Haskell]: https://haskell.org
-[SQLite]: https://sqlite.org
-[TaskLite]: https://tasklite.org
+## [Documentation](https://tasklite.org/)


### PR DESCRIPTION
The documentation link in README is outdated such as https://tasklite.org/installation/cli. This commit make the documentation link point to the project website.