### PR TITLE
Add ARM build support to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,18 @@ jobs:
           name: tasklite_linux_x86_64.zip
 
   macos:
-    runs-on: macos-14
+    strategy:
+      matrix:
+        arch: [x86_64, arm64]
+        include:
+          - arch: x86_64
+            runner: macos-14
+            artifact: tasklite_macos_x86_64
+          - arch: arm64
+            runner: macos-latest
+            artifact: tasklite_macos_arm64
+
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -68,8 +79,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .stack-work
-          key: tasklite_stack-work_macos
-          restore-keys: tasklite_stack-work_macos
+          key: tasklite_stack-work_macos_${{ matrix.arch }}
+          restore-keys: tasklite_stack-work_macos_${{ matrix.arch }}
 
       - name: Setup Stack
         uses: haskell-actions/setup@v2
@@ -93,7 +104,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: /Users/runner/.local/bin/tasklite
-          name: tasklite_macos_x86_64.zip
+          name: ${{ matrix.artifact }}
 
   docker:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,18 @@ on: [push]
 
 jobs:
   linux:
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        arch: [x86_64, arm64]
+        include:
+          - arch: x86_64
+            runner: ubuntu-22.04
+            artifact: tasklite_linux_x86_64
+          - arch: arm64
+            runner: ubuntu-latest
+            artifact: tasklite_linux_arm64
+
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -16,8 +27,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .stack-work
-          key: tasklite_stack-work_ubuntu
-          restore-keys: tasklite_stack-work_ubuntu
+          key: tasklite_stack-work_linux_${{ matrix.arch }}
+          restore-keys: tasklite_stack-work_linux_${{ matrix.arch }}
 
       - name: Setup Stack
         uses: haskell-actions/setup@v2
@@ -32,10 +43,10 @@ jobs:
             ~/.stack
             airsequel-cli/.stack-work
           key: >-
-            ${{ runner.os }}-stack-${{
+            ${{ runner.os }}-${{ matrix.arch }}-stack-${{
             hashFiles('stack.yaml.lock', 'airsequel-cli/package.yaml') }}
           restore-keys: |
-            ${{runner.os}}-stack
+            ${{runner.os}}-${{ matrix.arch }}-stack
 
       - name: Install TaskLite CLI tool
         run: stack install tasklite
@@ -53,7 +64,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: /home/runner/.local/bin/tasklite
-          name: tasklite_linux_x86_64.zip
+          name: ${{ matrix.artifact }}
 
   macos:
     strategy:


### PR DESCRIPTION
Closes #80.

Hey @ad-si! This PR adds multi-architecture build support to CI. It should enable builds for both ARM64 and x86_64 on Linux and MacOS.
