### PR TITLE
Update `ready` state to match documentation.

### DIFF
--- a/tasklite-core/source/Lib.hs
+++ b/tasklite-core/source/Lib.hs
@@ -2861,6 +2861,8 @@ listReady conf now connection availableLinesMb = do
           (ready_utc IS NULL OR
             (ready_utc IS NOT NULL AND ready_utc < datetime('now'))
           ) AND
+          waiting_utc IS NULL AND
+          ready_utc IS NULL AND
           closed_utc IS NULL
         ORDER BY
           priority DESC,


### PR DESCRIPTION
I am used to have a short, manageable task list. In taskwarrior, I use the waiting date to hide them from view.
In tasklite, I expected `waitt` and `waitFor` to hide task for the `ready`.
This PR fixed that and update the `ready` state to match the doc.