### PR TITLE
Fix #112.

### DIFF
--- a/tasklite-core/source/Cli.hs
+++ b/tasklite-core/source/Cli.hs
@@ -1455,6 +1455,8 @@ printOutput appName argsMb config = do
             Right hookResult -> formatHookResult conf hookResult
           & P.fold
 
+  -- isTTY <- queryTerminal stdOutput
+  -- if isTTY then size else 80
   termSizeMb <- size
   let
     linesNumMb =
@@ -1474,7 +1476,7 @@ printOutput appName argsMb config = do
         (Just termWidth, Just maxWidth) -> P.min termWidth maxWidth
         (Just termWidth, Nothing) -> termWidth
         (Nothing, Just maxWidth) -> maxWidth
-        (Nothing, Nothing) -> P.maxBound @P.Int
+        (Nothing, Nothing) -> 80
 
   nowElapsed <- timeCurrentP
   let now = timeFromElapsedP nowElapsed :: DateTime


### PR DESCRIPTION
When piping to cat or less, there is no TTY so no no terminal width. Default is to have super-long lines, which does not render well. I capped the output witdth at 80. I' not super satisfied with this hack but it works.