### PR TITLE
Add tags as a separate column.

### DIFF
--- a/tasklite-core/example-config.yaml
+++ b/tasklite-core/example-config.yaml
@@ -2,7 +2,8 @@ tableName: tasks
 
 # Select columns and their order for the table view.
 # `body` should be the last column, as its width varies for each task.
-columns: [id, prio, openedUtc, age, body]
+# tags column may need some manual adjustment, see `tagsWidth`
+columns: [id, prio, openedUtc, age, tags, body]
 
 idWidth: 4
 idStyle: green
@@ -31,6 +32,7 @@ dbName: main.db
 dateWidth: 10
 bodyWidth: 10
 prioWidth: 4
+tagsWidth: 20
 headCount: 20
 maxWidth: 120
 progressBarWidth: 24

--- a/tasklite-core/source/Config.hs
+++ b/tasklite-core/source/Config.hs
@@ -227,7 +227,7 @@ addHookFilesToConfig config = do
     (config, [])
 
 
-data Column = IdCol | PrioCol | OpenedUTCCol | AgeCol | BodyCol | EmptyCol
+data Column = IdCol | PrioCol | OpenedUTCCol | AgeCol | BodyCol | TagsCol | EmptyCol
   deriving (Eq, Show, Generic)
 
 
@@ -237,6 +237,7 @@ instance ToJSON Column where
   toJSON OpenedUTCCol = String "openedUtc"
   toJSON AgeCol = String "age"
   toJSON BodyCol = String "body"
+  toJSON TagsCol = String "tags"
   toJSON EmptyCol = String ""
 instance FromJSON Column where
   parseJSON = withText "Column" $ \value -> do
@@ -246,6 +247,7 @@ instance FromJSON Column where
       "openedUtc" -> pure OpenedUTCCol
       "age" -> pure AgeCol
       "body" -> pure BodyCol
+      "tags" -> pure TagsCol
       _ -> pure EmptyCol
 
 
@@ -268,6 +270,7 @@ data Config = Config
   , dateWidth :: Int
   , bodyWidth :: Int
   , prioWidth :: Int
+  , tagsWidth :: Int
   , headCount :: Int
   , maxWidth :: Maybe Int -- Automatically uses terminal width if not set
   , progressBarWidth :: Int
@@ -299,6 +302,7 @@ instance FromJSON Config where
     dateWidth       <- o .:? "dateWidth" .!= defaultConfig.dateWidth
     bodyWidth       <- o .:? "bodyWidth" .!= defaultConfig.bodyWidth
     prioWidth       <- o .:? "prioWidth" .!= defaultConfig.prioWidth
+    tagsWidth       <- o .:? "tagsWidth" .!= defaultConfig.tagsWidth
     headCount       <- o .:? "headCount" .!= defaultConfig.headCount
     maxWidthMb     <- o .:? "maxWidth"
     progressBarWidth <- o .:? "progressBarWidth"
@@ -391,12 +395,13 @@ defaultConfig =
     , tagStyle = color Blue
     , utcFormat = toFormat ("YYYY-MM-DD H:MI:S" :: [Char])
     , utcFormatShort = toFormat ("YYYY-MM-DD H:MI" :: [Char])
-    , columns = [IdCol, PrioCol, OpenedUTCCol, BodyCol]
+    , columns = [IdCol, PrioCol, OpenedUTCCol, BodyCol, TagsCol]
     , dataDir = ""
     , dbName = "main.db"
     , dateWidth = 10
     , bodyWidth = 10
     , prioWidth = 4
+    , tagsWidth = 20
     , headCount = 20
     , maxWidth = Nothing
     , progressBarWidth = 24


### PR DESCRIPTION
Here's a follow-up on the new column. I propose to add tags as a column before body and let the user set its width in the configuarion file..
I have several tags and not sure how to deal with the column width correctly at the moment

Tags format is more dense: instead of `+next +work +test`, I propose `next,work,test`
<img width="844" height="137" alt="20250728_21h58m24s_grim" src="https://github.com/user-attachments/assets/c0d1226a-b7cd-41cc-97a1-b906a1d15582" />
