### PR TITLE
Switch `time-hourglass` for unmaintained `hourglass`

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 # ATTENTION: Also use the corresponding GHC version in the Dockerfile
-resolver: lts-23.18
+snapshot: lts-23.27 # GHC 9.8.4
 system-ghc: true  # Installed via Nix
 
 packages:
@@ -12,6 +12,7 @@ extra-deps:
   - double-x-encoding-1.2.1
   - fuzzily-0.2.1.0
   - graphql-spice-1.0.2.0
+  - time-hourglass-0.3.0
 
   - github: Airsequel/simple-sql-parser
     commit: 680f2b77c53fcc086dc7d5f498f764ad2235b828

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -40,6 +40,13 @@ packages:
   original:
     hackage: graphql-spice-1.0.2.0
 - completed:
+    hackage: time-hourglass-0.3.0@sha256:ee02356fe24919ec43ae17fc0007398c2fd0bbe822833b2d7a9c849537b90580,3114
+    pantry-tree:
+      sha256: 7d6acc1a643fe8692d1858c96cc04a417b8da53e53b6bdba6fe0ce6aa6aba774
+      size: 1594
+  original:
+    hackage: time-hourglass-0.3.0
+- completed:
     name: simple-sql-parser
     pantry-tree:
       sha256: a7f399e93b6cb3056e43702b57ecda1a6a86dfdbeca4361ae3d2d27518ba4fe7
@@ -63,7 +70,7 @@ packages:
     url: https://github.com/meteogrid/iso8601-duration/archive/9524d1f02775be1d6c73165c4b4d62a19c8b7698.tar.gz
 snapshots:
 - completed:
-    sha256: d133abe75e408a407cce3f032c96ac1bbadf474a93b5156ebf4135b53382d56b
-    size: 683827
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/18.yaml
-  original: lts-23.18
+    sha256: 069c8189232279d04bd107557d3a62132c04ae5ce3c710649e6b40f67f10b9d5
+    size: 684285
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/27.yaml
+  original: lts-23.27

--- a/tasklite-core/package.yaml
+++ b/tasklite-core/package.yaml
@@ -1,5 +1,5 @@
 name: tasklite-core
-version: 0.5.0.0
+version: 0.6.0.0
 github: "ad-si/TaskLite"
 license: AGPL-3.0-or-later
 author: Adrian Sieber
@@ -64,7 +64,7 @@ library:
     - fuzzily >= 0.2 && < 0.3
     - generic-random >= 1.3 && < 1.6
     - githash >= 0.1.6 && < 0.2
-    - hourglass >= 0.2.10 && < 0.3
+    - time-hourglass >= 0.3.0 && < 0.4
     - hsemail >= 2.0 && < 2.3
     - iso8601-duration >= 0.1.1 && < 0.2
     - optparse-applicative >= 0.16 && < 0.19
@@ -104,7 +104,7 @@ tests:
     dependencies:
       - aeson
       - bytestring
-      - hourglass
+      - time-hourglass
       - hspec >= 2.11 && < 3.0
       - iso8601-duration
       - MissingH >= 1.4 && < 1.7

--- a/tasklite-core/source/ImportExport.hs
+++ b/tasklite-core/source/ImportExport.hs
@@ -116,7 +116,7 @@ import Prettyprinter.Render.Terminal (
  )
 import System.Directory (createDirectoryIfMissing, listDirectory, removeFile)
 import System.FilePath (isExtensionOf, takeExtension, (</>))
-import System.Hourglass (timeCurrentP)
+import Time.System (timeCurrentP)
 import System.Posix.User (getEffectiveUserName)
 import System.Process (readProcess)
 import Task (Task (..), emptyTask, setMetadataField, taskToEditableMarkdown)

--- a/tasklite-core/source/ImportTask.hs
+++ b/tasklite-core/source/ImportTask.hs
@@ -59,7 +59,7 @@ import Data.Time.ISO8601.Duration qualified as Iso
 import Data.ULID (ULID, ulidFromInteger)
 import FullTask qualified
 import Note (Note (..))
-import System.Hourglass (dateCurrent)
+import Time.System (dateCurrent)
 import Task (
   Task (
     Task,

--- a/tasklite-core/tasklite-core.cabal
+++ b/tasklite-core/tasklite-core.cabal
@@ -1,11 +1,11 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.38.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:           tasklite-core
-version:        0.5.0.0
+version:        0.6.0.0
 synopsis:       CLI task / todo list manager with SQLite backend
 description:    TaskLite is a CLI task / todo list manager with a SQLite backend.
                 It is designed to be simple and easy to use,
@@ -84,7 +84,6 @@ library
     , fuzzily ==0.2.*
     , generic-random >=1.3 && <1.6
     , githash >=0.1.6 && <0.2
-    , hourglass >=0.2.10 && <0.3
     , hsemail >=2.0 && <2.3
     , iso8601-duration >=0.1.1 && <0.2
     , optparse-applicative >=0.16 && <0.19
@@ -106,6 +105,7 @@ library
     , terminal-size ==0.3.*
     , text >=1.2 && <2.2
     , time >=1.11 && <1.15
+    , time-hourglass >=0.3.0 && <0.4
     , ulid ==0.3.*
     , unix ==2.8.*
     , vector >=0.12 && <0.14
@@ -149,7 +149,6 @@ test-suite tasklite-test
     , aeson
     , base >=4.18 && <5
     , bytestring
-    , hourglass
     , hspec >=2.11 && <3.0
     , iso8601-duration
     , neat-interpolation ==0.5.*
@@ -157,6 +156,7 @@ test-suite tasklite-test
     , sqlite-simple
     , tasklite-core
     , text
+    , time-hourglass
     , ulid
     , yaml
   default-language: GHC2021

--- a/tasklite-core/test/LibSpec.hs
+++ b/tasklite-core/test/LibSpec.hs
@@ -71,7 +71,7 @@ import Lib (
   updateTask,
  )
 import Note (Note)
-import System.Hourglass (dateCurrent)
+import Time.System (dateCurrent)
 import Task (
   Task (
     body,


### PR DESCRIPTION
Unmaintained `hourglass` has been forked as `time-hourglass`. See:

* https://discourse.haskell.org/t/fork-hourglass-as-time-hourglass/12460
* https://discourse.haskell.org/t/hourglass-forked-as-time-hourglass/12520
* https://hackage.haskell.org/package/time-hourglass

Also imports `Time.System` to replace deprecated `System.Hourglass` module.

Also bumps `stack.yaml` to most recent Stackage LTS Haskell for the GHC 9.8 series.