### PR TITLE
Enable users to define their own shortcuts via the config file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,10 +72,10 @@ jobs:
         arch: [x86_64, arm64]
         include:
           - arch: x86_64
-            runner: macos-14
+            runner: macos-15-intel
             artifact: tasklite_macos_x86_64
           - arch: arm64
-            runner: macos-latest
+            runner: macos-26
             artifact: tasklite_macos_arm64
 
     runs-on: ${{ matrix.runner }}

--- a/docs-source/cli/usage.md
+++ b/docs-source/cli/usage.md
@@ -40,6 +40,48 @@ It is also possible to immediately add tags when creating a task:
 tl add Improve the TaskLite manual +tasklite +pc
 ```
 
+### Built-in Shortcuts
+
+TaskLite provides several built-in shortcuts to quickly add tasks with common tags:
+
+- `tl write "Email to John"` → Adds "Write Email to John +write"
+- `tl read "Article about Haskell"` → Adds "Read Article about Haskell +read"
+- `tl idea "New feature"` → Adds "New feature +idea"
+- `tl watch "Haskell tutorial"` → Adds "Watch Haskell tutorial +watch"
+- `tl listen "Podcast episode"` → Adds "Listen Podcast episode +listen"
+- `tl buy "Groceries"` → Adds "Buy Groceries +buy"
+- `tl sell "Old laptop"` → Adds "Sell Old laptop +sell"
+- `tl pay "Electric bill"` → Adds "Pay Electric bill +pay"
+- `tl ship "Package to Mom"` → Adds "Ship Package to Mom +ship"
+
+### Custom Shortcuts
+
+You can also define your own shortcuts in the config file.
+For example, to add shortcuts for `cook`, `call`, and `fix`:
+
+```yaml
+shortcuts:
+  cook:
+    prefix: Cook
+    tag: cook
+  call:
+    prefix: Call
+    tag: call
+  fix:
+    tag: fix  # No prefix, just adds the tag
+```
+
+With this configuration:
+
+- `tl cook dinner` → Adds "Cook dinner +cook"
+- `tl call Mom` → Adds "Call Mom +call"
+- `tl fix login bug` → Adds "login bug +fix"
+
+Each shortcut has the following fields:
+
+- `prefix` (optional): Text to prepend to the task body
+- `tag`: Tag to add to the task (without the `+` prefix)
+
 And even to set certain fields:
 
 ```shell

--- a/docs-source/cli/usage.md
+++ b/docs-source/cli/usage.md
@@ -57,7 +57,7 @@ TaskLite provides several built-in shortcuts to quickly add tasks with common ta
 ### Custom Shortcuts
 
 You can also define your own shortcuts in the config file.
-For example, to add shortcuts for `cook`, `call`, and `fix`:
+For example, to add shortcuts for `cook`, `call`, `fix`, and `shopping`:
 
 ```yaml
 shortcuts:
@@ -69,6 +69,12 @@ shortcuts:
     tag: call
   fix:
     tag: fix  # No prefix, just adds the tag
+  shopping:
+    prefix: Buy
+    tags: [shopping, errands]  # Multiple tags
+  quick:
+    prefix: Do
+    tags: []  # No tags, just the prefix
 ```
 
 With this configuration:
@@ -76,11 +82,17 @@ With this configuration:
 - `tl cook dinner` → Adds "Cook dinner +cook"
 - `tl call Mom` → Adds "Call Mom +call"
 - `tl fix login bug` → Adds "login bug +fix"
+- `tl shopping milk` → Adds "Buy milk +shopping +errands"
+- `tl quick something` → Adds "Do something"
 
 Each shortcut has the following fields:
 
 - `prefix` (optional): Text to prepend to the task body
-- `tag`: Tag to add to the task (without the `+` prefix)
+- `tag` (optional): Single tag to add to the task (without the `+` prefix)
+- `tags` (optional): List of tags to add to the task (without the `+` prefix)
+
+You can use either `tag` for a single tag or `tags` for multiple tags.
+If both are specified, they are combined.
 
 And even to set certain fields:
 

--- a/tasklite-core/example-config.yaml
+++ b/tasklite-core/example-config.yaml
@@ -45,8 +45,9 @@ progressBarWidth: 24
 #       - interpreter: python3
 #         body: print('Python test')
 
-# Custom shortcuts to quickly add tasks with a tag.
+# Custom shortcuts to quickly add tasks with tags.
 # For example: `tl cook Dinner` will add a task "Cook Dinner +cook"
+# You can use either `tag` for a single tag or `tags` for multiple tags.
 # shortcuts:
 #   cook:
 #     prefix: Cook
@@ -65,3 +66,8 @@ progressBarWidth: 24
 #     tag: email
 #   fix:
 #     tag: fix
+#   shopping:
+#     prefix: Buy
+#     tags: [shopping, errands]  # Multiple tags
+#   quick:
+#     tags: []  # No tags, just the prefix

--- a/tasklite-core/example-config.yaml
+++ b/tasklite-core/example-config.yaml
@@ -44,3 +44,24 @@ progressBarWidth: 24
 #     pre:
 #       - interpreter: python3
 #         body: print('Python test')
+
+# Custom shortcuts to quickly add tasks with a tag.
+# For example: `tl cook Dinner` will add a task "Cook Dinner +cook"
+# shortcuts:
+#   cook:
+#     prefix: Cook
+#     tag: cook
+#   wash:
+#     prefix: Wash
+#     tag: wash
+#   print:
+#     prefix: Print
+#     tag: print
+#   call:
+#     prefix: Call
+#     tag: call
+#   email:
+#     prefix: Email
+#     tag: email
+#   fix:
+#     tag: fix

--- a/tasklite-core/package.yaml
+++ b/tasklite-core/package.yaml
@@ -59,6 +59,7 @@ library:
     - ansi-terminal >= 0.11 && < 1.2
     - bytestring >= 0.11 && < 0.13
     - cassava >= 0.5.2 && < 0.6
+    - containers >= 0.6 && < 0.8
     - colour >= 2.3 && < 2.4
     - directory >= 1.3 && < 1.4
     - editor-open >= 0.4 && < 0.7

--- a/tasklite-core/source/Cli.hs
+++ b/tasklite-core/source/Cli.hs
@@ -463,7 +463,10 @@ getShortcutCommand (cmdName, shortcut) =
   where
     description = case shortcut.prefix of
       Just pfx -> pfx <> " something (custom shortcut)"
-      Nothing -> "Add task with +" <> shortcut.tag <> " tag (custom shortcut)"
+      Nothing -> case shortcut.tags of
+        [] -> "Add task (custom shortcut)"
+        [t] -> "Add task with +" <> t <> " tag (custom shortcut)"
+        ts -> "Add task with " <> T.intercalate ", " (fmap ("+" <>) ts) <> " tags (custom shortcut)"
 
 
 toParserInfo :: Parser a -> Text -> ParserInfo a
@@ -1376,9 +1379,9 @@ executeCLiCommand config now connection progName args availableLinesMb = do
             prefixWords = case shortcut.prefix of
               Just pfx -> [pfx]
               Nothing -> []
-            tagWord = "+" <> shortcut.tag
+            tagWords = fmap ("+" <>) shortcut.tags
           in
-            addTaskC $ prefixWords <> bodyWords <> [tagWord]
+            addTaskC $ prefixWords <> bodyWords <> tagWords
         LogTask bodyWords -> logTask conf connection bodyWords
         EnterTask -> enterTask conf connection
         ReadyOn datetime ids -> setReadyUtc conf connection datetime ids

--- a/tasklite-core/source/Config.hs
+++ b/tasklite-core/source/Config.hs
@@ -29,6 +29,9 @@ import Protolude (
  )
 import Protolude qualified as P
 
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+
 import Data.Aeson (
   FromJSON (parseJSON),
   ToJSON (toJSON),
@@ -105,6 +108,26 @@ data HooksConfig = HooksConfig
   -- TODO: , delete :: HookSet
   }
   deriving (Generic, Show)
+
+
+-- | Custom shortcut for adding tasks with predefined prefix and tag
+data Shortcut = Shortcut
+  { prefix :: Maybe Text
+  -- ^ Optional prefix to prepend to task body (e.g., "Cook")
+  , tag :: Text
+  -- ^ Tag to add to the task (without the + prefix)
+  }
+  deriving (Eq, Generic, Show)
+
+
+instance ToJSON Shortcut
+
+
+instance FromJSON Shortcut where
+  parseJSON = withObject "shortcut" $ \o -> do
+    prefix <- o .:? "prefix"
+    tag <- o .:? "tag" .!= ""
+    pure $ Shortcut{..}
 
 
 instance ToJSON HooksConfig
@@ -285,6 +308,8 @@ data Config = Config
   , maxWidth :: Maybe Int -- Automatically uses terminal width if not set
   , progressBarWidth :: Int
   , hooks :: HooksConfig
+  , shortcuts :: Map Text Shortcut
+  -- ^ Custom shortcuts for adding tasks (e.g., "cook" -> adds "Cook" prefix and "+cook" tag)
   , noColor :: Bool
   }
   deriving (Generic, Show)
@@ -318,6 +343,7 @@ instance FromJSON Config where
     progressBarWidth <- o .:? "progressBarWidth"
                                 .!= defaultConfig.progressBarWidth
     hooks           <- o .:? "hooks" .!= defaultConfig.hooks
+    shortcuts       <- o .:? "shortcuts" .!= defaultConfig.shortcuts
     noColor         <- o .:? "noColor" .!= defaultConfig.noColor
 
     let maxWidth = maxWidthMb >>=
@@ -423,5 +449,6 @@ defaultConfig =
           , modify = emptyHookSet
           , exit = emptyHookSet
           }
+    , shortcuts = Map.empty
     , noColor = False
     }

--- a/tasklite-core/tasklite-core.cabal
+++ b/tasklite-core/tasklite-core.cabal
@@ -80,6 +80,7 @@ library
     , bytestring >=0.11 && <0.13
     , cassava >=0.5.2 && <0.6
     , colour ==2.3.*
+    , containers >=0.6 && <0.8
     , directory ==1.3.*
     , editor-open >=0.4 && <0.7
     , exceptions ==0.10.*

--- a/tasklite-core/test/TypesSpec.hs
+++ b/tasklite-core/test/TypesSpec.hs
@@ -2,12 +2,12 @@
 
 module TypesSpec where
 
-import Protolude (Maybe (..), Text, ($), (&), (<&>), (<>))
+import Protolude (Either (..), Maybe (..), Text, ($), (&), (<&>), (<>))
 import Protolude qualified as P
 
 import Test.Hspec (Spec, describe, it, shouldBe)
 
-import Config (defaultConfig)
+import Config (Shortcut (..), defaultConfig)
 import Data.Text qualified as T
 import Data.Yaml qualified
 import FullTask (FullTask (body, notes, tags, ulid), emptyFullTask)
@@ -174,3 +174,56 @@ spec = do
             <> "\n"
 
       taskYaml `shouldBe` expected
+
+  describe "Shortcut" $ do
+    it "can be parsed from YAML with prefix and tag" $ do
+      let
+        shortcutYaml :: P.ByteString
+        shortcutYaml =
+          [trimming|
+              prefix: Cook
+              tag: cook
+            |]
+
+        expected :: Shortcut
+        expected =
+          Shortcut
+            { prefix = Just "Cook"
+            , tag = "cook"
+            }
+
+      Data.Yaml.decodeEither' shortcutYaml `shouldBe` Right expected
+
+    it "can be parsed from YAML with tag only" $ do
+      let
+        shortcutYaml :: P.ByteString
+        shortcutYaml =
+          [trimming|
+              tag: fix
+            |]
+
+        expected :: Shortcut
+        expected =
+          Shortcut
+            { prefix = Nothing
+            , tag = "fix"
+            }
+
+      Data.Yaml.decodeEither' shortcutYaml `shouldBe` Right expected
+
+    it "defaults to empty tag when tag is not specified" $ do
+      let
+        shortcutYaml :: P.ByteString
+        shortcutYaml =
+          [trimming|
+              prefix: Cook
+            |]
+
+        expected :: Shortcut
+        expected =
+          Shortcut
+            { prefix = Just "Cook"
+            , tag = ""
+            }
+
+      Data.Yaml.decodeEither' shortcutYaml `shouldBe` Right expected

--- a/tasklite/package.yaml
+++ b/tasklite/package.yaml
@@ -62,6 +62,7 @@ tests:
     main: Spec.hs
     source-dirs: test
     dependencies:
+      - containers >= 0.6 && < 0.8
       - directory
       - hspec >= 2.11 && < 3.0
       - optparse-applicative >= 0.16 && < 0.19

--- a/tasklite/tasklite.cabal
+++ b/tasklite/tasklite.cabal
@@ -82,6 +82,7 @@ test-suite tasklite-test
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wno-orphans -Wredundant-constraints -Wunused-packages
   build-depends:
       base >=4.18 && <5
+    , containers >=0.6 && <0.8
     , directory
     , hspec >=2.11 && <3.0
     , optparse-applicative >=0.16 && <0.19

--- a/tasklite/test/CliSpec.hs
+++ b/tasklite/test/CliSpec.hs
@@ -33,7 +33,13 @@ import Cli (
   printOutput,
   renderIOWithConfig,
  )
-import Config (Config, Hook (Hook), HookSet (HookSet), Shortcut (Shortcut), defaultConfig)
+import Config (
+  Config,
+  Hook (Hook),
+  HookSet (HookSet),
+  Shortcut (Shortcut),
+  defaultConfig,
+ )
 import Config qualified
 import Data.Map.Strict qualified as Map
 import System.Directory (
@@ -251,7 +257,7 @@ spec tmpDirPath = do
         testShortcut =
           Shortcut
             { Config.prefix = Just "Cook"
-            , Config.tag = "cook"
+            , Config.tags = ["cook"]
             }
         testConf =
           defaultConfig
@@ -274,7 +280,7 @@ spec tmpDirPath = do
         testShortcut =
           Shortcut
             { Config.prefix = Just "Cook"
-            , Config.tag = "cook"
+            , Config.tags = ["cook"]
             }
         testConf =
           defaultConfig
@@ -290,7 +296,7 @@ spec tmpDirPath = do
         testShortcut =
           Shortcut
             { Config.prefix = Nothing
-            , Config.tag = "fix"
+            , Config.tags = ["fix"]
             }
         testConf =
           defaultConfig


### PR DESCRIPTION
Enable users to define their own shortcuts via the config file. This implements feature request #78.

- Add Shortcut data type to Config.hs with prefix and tag fields
- Add shortcuts map to Config for storing custom shortcuts
- Modify CLI parser to dynamically add commands from config shortcuts
- Update example-config.yaml with shortcut examples
- Add tests for shortcut parsing and CLI integration
- Add documentation for built-in and custom shortcuts

Example config:
```yaml
shortcuts:
  cook:
    prefix: Cook
    tag: cook
  fix:
    tag: fix
```

With this, `tl cook dinner` adds task "Cook dinner +cook"